### PR TITLE
Custom and dynamic row classes and optionally remove odd/even classes

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -238,30 +238,29 @@ will product html like:
     </tbody>
   </table>
 
-For that last extra squeeze of micro-management, you can pass in a block to customize row classes:
+=== Customizing row classes
+
+For that last extra squeeze of micro-management, you can customize row classes by passing in a block:
   <%= table_for(@posts) do |t|
     t.row_class { |post| post.title }
+    t.data(:title)
   end %>
 
-Or with a string:
+Or just using a string:
 
   <%= table_for(@posts) do |t|
     t.row_class("foobar")
-    t.data do
-      t.cell(:title)
-    end
+    t.data(:title)
   end %>
 
 You can also choose to omit the odd and even classes:
 
   <%= table_for(@posts) do |t|
-    t.row_class(odd_even: false) { |post| post.title }
-    t.data do
-      t.cell(:title)
-    end
+    t.row_class("foobar", odd_even: false)
+    t.data(:title)
   end %>
 
-In HAML you would have to use a dash instead of an equals sign:
+In HAML you have to use a dash instead of an equals sign:
 
   = table_for(@posts) do |t|
     - t.row_class("foo")

--- a/README.rdoc
+++ b/README.rdoc
@@ -238,7 +238,7 @@ will product html like:
     </tbody>
   </table>
 
-For that last extra squeeze of micro-management, you can pass in a block to customize row classes with a block:
+For that last extra squeeze of micro-management, you can pass in a block to customize row classes:
   <%= table_for(@posts) do |t|
     t.row_class { |post| post.title }
   end %>
@@ -260,6 +260,12 @@ You can also choose to omit the odd and even classes:
       t.cell(:title)
     end
   end %>
+
+In HAML you would have to use a dash instead of an equals sign:
+
+  = table_for(@posts) do |t|
+    - t.row_class("foo")
+    = t.data
 
 
 If it _still_ isn't flexible enough for your needs, it might be time to return to static html/erb.

--- a/README.rdoc
+++ b/README.rdoc
@@ -238,6 +238,22 @@ will product html like:
     </tbody>
   </table>
 
+For that last extra squeeze of micro-management, you can use the data block to customize row classes with a block:
+  <%= table_for(@posts) do |t|
+    t.data do
+      t.row_class { |post| post.title }
+    end
+  end %>
+
+Or with a string
+  <%= table_for(@posts) do |t|
+    t.data do
+      t.row_class("foobar")
+    end
+  end %>
+
+
+
 
 If it _still_ isn't flexible enough for your needs, it might be time to return to static html/erb.
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -238,21 +238,28 @@ will product html like:
     </tbody>
   </table>
 
-For that last extra squeeze of micro-management, you can use the data block to customize row classes with a block:
+For that last extra squeeze of micro-management, you can pass in a block to customize row classes with a block:
   <%= table_for(@posts) do |t|
+    t.row_class { |post| post.title }
+  end %>
+
+Or with a string:
+
+  <%= table_for(@posts) do |t|
+    t.row_class("foobar")
     t.data do
-      t.row_class { |post| post.title }
+      t.cell(:title)
     end
   end %>
 
-Or with a string
+You can also choose to omit the odd and even classes:
+
   <%= table_for(@posts) do |t|
+    t.row_class(odd_even: false) { |post| post.title }
     t.data do
-      t.row_class("foobar")
+      t.cell(:title)
     end
   end %>
-
-
 
 
 If it _still_ isn't flexible enough for your needs, it might be time to return to static html/erb.

--- a/Rakefile
+++ b/Rakefile
@@ -42,7 +42,7 @@ RSpec::Core::RakeTask.new(:rcov) do |spec|
 end
 
 
-require 'rake/rdoctask'
+require 'rdoc/task'
 Rake::RDocTask.new do |rdoc|
   version = File.exist?('VERSION') ? File.read('VERSION') : ""
 

--- a/lib/tabletastic/table_builder.rb
+++ b/lib/tabletastic/table_builder.rb
@@ -122,6 +122,23 @@ module Tabletastic
       self.cell(action, :heading => "", :cell_html => {:class => html_class}, &block)
     end
 
+    # Pass in a string to specify a class for each row
+    # For example:
+    #
+    #   row_class("foo")
+    #
+    #   <tr class="post odd foo"> ... </tr>
+    #
+    # Pass in an additional option to remove the odd/even classes, like so:
+    #
+    #   row_class("foo", odd_even: false) 
+    #
+    #   <tr class="post foo"> ... </tr>
+    #
+    # You can create dynamic classes by passing a block:
+    #
+    #   row_class {|post| post.my_custom_class_creating_method}
+    #
     def row_class(*args, &block)
       options = args.extract_options!
       css_block = block || lambda { |resource| args.first }

--- a/lib/tabletastic/version.rb
+++ b/lib/tabletastic/version.rb
@@ -1,3 +1,3 @@
 module Tabletastic
-  VERSION = "0.2.3"
+  VERSION = "0.2.4"
 end

--- a/spec/tabletastic/table_builder_spec.rb
+++ b/spec/tabletastic/table_builder_spec.rb
@@ -287,7 +287,7 @@ describe Tabletastic::TableBuilder do
         context "and a block" do
           before do
             concat(table_for(@posts) do |t|
-              t.row_class(odd_even: false) { |post| post.foo }
+              t.row_class(:odd_even => false) { |post| post.foo }
               t.data
             end)
           end
@@ -300,7 +300,7 @@ describe Tabletastic::TableBuilder do
         context "and string" do
           before do
             concat(table_for(@posts) do |t|
-              t.row_class("foo", odd_even: false)
+              t.row_class("foo", :odd_even => false)
               t.data
             end)
           end

--- a/spec/tabletastic/table_builder_spec.rb
+++ b/spec/tabletastic/table_builder_spec.rb
@@ -10,6 +10,7 @@ describe Tabletastic::TableBuilder do
     @post.stub!(:body).and_return("Lorem ipsum")
     @post.stub!(:created_at).and_return(Time.now)
     @post.stub!(:id).and_return(2)
+    @post.stub!(:foo).and_return("bar")
     @posts = [@post]
   end
 
@@ -253,7 +254,68 @@ describe Tabletastic::TableBuilder do
       it { should have_tag("td", "The title of the post") }
       it { should have_tag("td", "Lorem ipsum") }
     end
+    
+    context "with a custom row class" do
+      context "and odd-even" do
+        context "and string" do
+          before do
+            concat(table_for(@posts) do |t|
+              t.data do
+                t.row_class("foo")
+              end
+            end)
+          end
 
+          subject { output_buffer }
+
+          it { should have_tag("tr.foo.odd") }
+        end
+        context "and a block" do
+          before do
+            concat(table_for(@posts) do |t|
+              t.data do
+                t.row_class { |post| post.foo }
+              end
+            end)
+          end
+
+          subject { output_buffer }
+
+          it { should have_tag("tr.bar.odd") }
+        end
+      end
+
+      context "without odd even" do
+        context "and a block" do
+          before do
+            concat(table_for(@posts) do |t|
+              t.data do
+                t.row_class(odd_even: false) { |post| post.foo }
+              end
+            end)
+          end
+
+          subject { output_buffer }
+
+          it { should have_tag ("tr.bar") }
+          it { should_not have_tag("tr.bar.odd") }
+        end
+        context "and string" do
+          before do
+            concat(table_for(@posts) do |t|
+              t.data do
+                t.row_class("foo", odd_even: false)
+              end
+            end)
+          end
+
+          subject { output_buffer }
+          it { should_not have_tag("tr.foo.odd") }
+          it { should have_tag("tr.foo") }
+        end
+      end
+    end
+    
     context "with custom cell options" do
       before do
         concat(table_for(@posts) do |t|

--- a/spec/tabletastic/table_builder_spec.rb
+++ b/spec/tabletastic/table_builder_spec.rb
@@ -260,9 +260,8 @@ describe Tabletastic::TableBuilder do
         context "and string" do
           before do
             concat(table_for(@posts) do |t|
-              t.data do
-                t.row_class("foo")
-              end
+              t.row_class("foo")
+              t.data
             end)
           end
 
@@ -273,9 +272,8 @@ describe Tabletastic::TableBuilder do
         context "and a block" do
           before do
             concat(table_for(@posts) do |t|
-              t.data do
-                t.row_class { |post| post.foo }
-              end
+              t.row_class { |post| post.foo }
+              t.data
             end)
           end
 
@@ -289,9 +287,8 @@ describe Tabletastic::TableBuilder do
         context "and a block" do
           before do
             concat(table_for(@posts) do |t|
-              t.data do
-                t.row_class(odd_even: false) { |post| post.foo }
-              end
+              t.row_class(odd_even: false) { |post| post.foo }
+              t.data
             end)
           end
 
@@ -303,9 +300,8 @@ describe Tabletastic::TableBuilder do
         context "and string" do
           before do
             concat(table_for(@posts) do |t|
-              t.data do
-                t.row_class("foo", odd_even: false)
-              end
+              t.row_class("foo", odd_even: false)
+              t.data
             end)
           end
 

--- a/tabletastic.gemspec
+++ b/tabletastic.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.require_path = 'lib'
   s.required_rubygems_version = ">= 1.3.6"
-  s.add_runtime_dependency('activesupport', '~> 3.0')
+  s.add_runtime_dependency('activesupport', '> 3.0')
   s.test_files = Dir.glob("spec/**/*_spec.rb") + %w{spec/spec_helper.rb}
   s.add_development_dependency "rspec"
 end


### PR DESCRIPTION
For your consideration: another way of specifying classes for rows, see issues #21 and #24. In my solution we do this by calling `row_class` in the block passed to `table_for`.
You can use a string or pass a block to create dynamic classes. 

Syntax may be a bit suboptimal, since you shouldn't output the result of the method call. 

I also added an option to omit the odd/even classes by passing an option to `row_class`, as per issue #28
